### PR TITLE
Use edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yes-rs"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 authors = ["Rust Evangelist <rust@blazing.fast>"]
 description = "🚀 A blazingly fast, memory-safe rewrite of the classic Unix 'yes' command. Written in Rust! 🦀"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It's time to use rust edition 2024 released in 2025!